### PR TITLE
s/Crypt::SSLeay/IO::Socket::SSL/

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ name 'WebService-Prowl';
 all_from 'lib/WebService/Prowl.pm';
 
 requires 'LWP::UserAgent';
-requires 'Crypt::SSLeay';
+requires 'IO::Socket::SSL';
 requires 'Carp';
 requires 'XML::Simple';
 requires 'URI::Escape';


### PR DESCRIPTION
Hi,

I recently tried installing WebService::Prowl for a fresh build of Perl and cpanm blew up when encountering Crypt::SSLeay as a dependency. IO::Socket::SSL appears to be the better choice, so it might be worth deploying this change to CPAN.
