### PR TITLE
Change dependency on IO::Socket::SSL to LWP::Protocol::https

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ name 'WebService-Prowl';
 all_from 'lib/WebService/Prowl.pm';
 
 requires 'LWP::UserAgent' => '6.02';
-requires 'IO::Socket::SSL';
+requires 'LWP::Protocol::https';
 requires 'Carp';
 requires 'XML::Simple';
 requires 'URI::Escape';


### PR DESCRIPTION
Arguably this is the correct approach, since we just need SSL support, not any specific SSL library.

This is a continuation of PR #2.
